### PR TITLE
support json marshal for null value

### DIFF
--- a/nullable.go
+++ b/nullable.go
@@ -33,6 +33,9 @@ func (t Nullable[T]) Value() T {
 }
 
 func (t Nullable[T]) MarshalJSON() ([]byte, error) {
+	if t.IsNull() {
+		return json.Marshal(nil)
+	}
 	return json.Marshal(t.Value())
 }
 

--- a/nullable_test.go
+++ b/nullable_test.go
@@ -52,6 +52,14 @@ func TestNullable_MarshalJSON(t *testing.T) {
 	actualBytes, err := json.Marshal(actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBytes, actualBytes)
+
+	actualBytes, err = json.Marshal(struct {
+		Int Nullable[int] `json:"int"`
+	}{
+		Int: Nullable[int]{},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, `{"int":null}`, string(actualBytes))
 }
 
 func TestNullable_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
```go
b, err := json.Marshal(struct {
	Int Nullable[int] `json:"int"`
}{
	Int: Nullable[int]{},
})
if err != nil {
	panic(err)
}
fmt.Println(string(b)) // {"int":null}
```